### PR TITLE
Add NamedEnum::getNames() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $object->foo = MyEnum::BAR;
 echo MyEnum::getName($object->foo); // Bar name
 ```
 
+Check [NamedEnum's public methods](src/Enum/NamedEnum.php) for more usages examples.
+
 ## Testing
 
 ```bash

--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -15,6 +15,11 @@ abstract class NamedEnum
         return $itemClass->getConstants();
     }
 
+    public static function getNames(): array
+    {
+        return static::$VALUE_NAMES;
+    }
+
     public static function getName($value): ?string
     {
         return static::$VALUE_NAMES[$value] ?? null;

--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -17,7 +17,7 @@ abstract class NamedEnum
 
     public static function getName($value): ?string
     {
-        return array_key_exists($value, static::$VALUE_NAMES) ? static::$VALUE_NAMES[$value] : null;
+        return static::$VALUE_NAMES[$value] ?? null;
     }
 
     public static function values(): array

--- a/tests/Enum/NamedEnumTest.php
+++ b/tests/Enum/NamedEnumTest.php
@@ -16,6 +16,18 @@ final class NamedEnumTest extends TestCase
         $this->assertEquals('NAME STRING', TestEnum::getName(TestEnum::VALUE_STRING));
     }
 
+    public function testCanGetNames(): void
+    {
+        $this->assertEquals(
+            [
+                TestEnum::VALUE_1 => 'NAME 1',
+                TestEnum::VALUE_2 => 'NAME 2',
+                TestEnum::VALUE_STRING => 'NAME STRING'
+            ],
+            TestEnum::getNames()
+        );
+    }
+
     public function testCanGetAllNames(): void
     {
         $names = ['NAME 1', 'NAME 2', 'NAME STRING'];


### PR DESCRIPTION
This PR adds the `NamedEnum::getNames()` method, which allows us to access `$VALUE_NAMES` publicly.