### PR TITLE
Add NamedEnum::ensureValid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bf18694125b6a642a6840b423d5b7ea",
+    "content-hash": "69f889acf6d04f3396143cdfc2eb1975",
     "packages": [],
     "packages-dev": [
         {
@@ -2240,7 +2240,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-json": "*"
     },
     "platform-dev": []
 }

--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -3,6 +3,8 @@
 namespace Mesavolt\Enum;
 
 
+use Mesavolt\Helper\VariableDumper;
+
 /**
  * Extend this class and implement a static $VALUE_NAMES property
  * to benefit from all the methods defined here.
@@ -74,5 +76,26 @@ abstract class NamedEnum
         }
 
         return $array;
+    }
+
+    public static function ensureValid($value, string $callerMethod, bool $nullable = false, bool $strictCheck = true): void
+    {
+        // Null and nullable is allowed
+        if ($nullable && $value === null) {
+            return;
+        }
+
+        $validChoices = self::values();
+
+        if (!\in_array($value, $validChoices, $strictCheck)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid argument provided to %s - expected one of "%s", got "%s"',
+                    $callerMethod,
+                    implode(', ', $validChoices),
+                    VariableDumper::dump($value)
+                )
+            );
+        }
     }
 }

--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -78,21 +78,30 @@ abstract class NamedEnum
         return $array;
     }
 
-    public static function ensureValid($value, string $callerMethod, bool $nullable = false, bool $strictCheck = true): void
+    /**
+     * Returns true if the specified value is declared as one of this enum values.
+     */
+    public static function isValid($value, bool $nullable = false, bool $strictCheck = true): bool
     {
         // Null and nullable is allowed
         if ($nullable && $value === null) {
-            return;
+            return true;
         }
 
-        $validChoices = self::values();
+        return \in_array($value, self::values(), $strictCheck);
+    }
 
-        if (!\in_array($value, $validChoices, $strictCheck)) {
+    /**
+     * Throws an exception if the specified value is not declared as one of this enum values.
+     */
+    public static function ensureValid($value, string $callerMethod, bool $nullable = false, bool $strictCheck = true): void
+    {
+        if (!self::isValid($value, $nullable, $strictCheck)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     'Invalid argument provided to %s - expected one of "%s", got "%s"',
                     $callerMethod,
-                    implode(', ', $validChoices),
+                    implode(', ', self::values()),
                     VariableDumper::dump($value)
                 )
             );

--- a/src/Helper/VariableDumper.php
+++ b/src/Helper/VariableDumper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mesavolt\Helper;
+
+abstract class VariableDumper
+{
+    public static function dump($variable): string
+    {
+        switch ($type = \gettype($variable)) {
+            case 'NULL':
+                return 'null';
+            case 'boolean':
+            case 'integer':
+            case 'double':
+                return json_encode($variable);
+            case 'string':
+                return mb_substr($variable, 0, 100);
+            case 'array':
+            case 'resource':
+                return $type;
+            case 'object':
+                return \get_class($variable);
+            default:
+                return 'unknown';
+        }
+    }
+}

--- a/src/Helper/VariableDumper.php
+++ b/src/Helper/VariableDumper.php
@@ -15,13 +15,12 @@ abstract class VariableDumper
                 return json_encode($variable);
             case 'string':
                 return mb_substr($variable, 0, 100);
-            case 'array':
-            case 'resource':
-                return $type;
             case 'object':
                 return \get_class($variable);
+            case 'array':
+            case 'resource':
             default:
-                return 'unknown';
+                return $type;
         }
     }
 }

--- a/tests/Enum/NamedEnumTest.php
+++ b/tests/Enum/NamedEnumTest.php
@@ -81,7 +81,7 @@ final class NamedEnumTest extends TestCase
         $this->assertNull(TestEnum::getName(-1));
     }
 
-    public function testCanGetArrays()
+    public function testCanGetArrays(): void
     {
         $arrays = [
             ['name' => 'NAME 1', 'value' => 1],
@@ -90,5 +90,61 @@ final class NamedEnumTest extends TestCase
         ];
 
         $this->assertEquals(TestEnum::arrays(), $arrays);
+    }
+
+    public function testEnsureValid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument provided to Mesavolt\Tests\Enum\NamedEnumTest::testEnsureValid - expected one of "1, 2, string", got "banana"');
+
+        TestEnum::ensureValid('banana', __METHOD__);
+    }
+
+    public function dataProvider_ensureValidExceptionMessage(): array
+    {
+        return [
+            [null, 'null'],
+            [false, 'false'],
+            [true, 'true'],
+            [new \Exception(), \Exception::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider_ensureValidExceptionMessage
+     */
+    public function testEnsureValidExceptionMessage($value, string $expectedStringRepresentation): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument provided to Mesavolt\Tests\Enum\NamedEnumTest::testEnsureValidExceptionMessage - expected one of "1, 2, string", got "'.$expectedStringRepresentation.'"');
+        TestEnum::ensureValid($value, __METHOD__);
+    }
+
+    public function testEnsureValidWithNonNullable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument provided to Mesavolt\Tests\Enum\NamedEnumTest::testEnsureValidWithNonNullable - expected one of "1, 2, string", got "null"');
+
+        TestEnum::ensureValid(null, __METHOD__);
+    }
+
+    public function testEnsureValidWithNullable(): void
+    {
+        TestEnum::ensureValid(null, __METHOD__, true);
+        $this->assertTrue(true);
+    }
+
+    public function testEnsureValidWithStrictCheck(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid argument provided to Mesavolt\Tests\Enum\NamedEnumTest::testEnsureValidWithStrictCheck - expected one of "1, 2, string", got "1"');
+
+        TestEnum::ensureValid('1', __METHOD__, false, true);
+    }
+
+    public function testEnsureValidWithNonStrictCheck(): void
+    {
+        TestEnum::ensureValid('1', __METHOD__, false, false);
+        $this->assertTrue(true);
     }
 }

--- a/tests/Helper/VariableDumperTest.php
+++ b/tests/Helper/VariableDumperTest.php
@@ -24,6 +24,8 @@ class VariableDumperTest extends TestCase
             // object
             [new \stdClass(), 'stdClass'],
             [new \Exception(), \Exception::class],
+            // resouruce
+            [fopen(__FILE__, 'r'), 'resource']
         ];
     }
 

--- a/tests/Helper/VariableDumperTest.php
+++ b/tests/Helper/VariableDumperTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mesavolt\Tests\Helper;
+
+use Mesavolt\Helper\VariableDumper;
+use PHPUnit\Framework\TestCase;
+
+class VariableDumperTest extends TestCase
+{
+    public function dataProvider_dump(): array
+    {
+        return [
+            // boolean
+            [true, 'true'],
+            [false, 'false'],
+            // integer
+            [0, '0'],
+            // double
+            [1.1, '1.1'],
+            // string
+            ['str', 'str'],
+            // array
+            [[1, 2, 3], 'array'],
+            // object
+            [new \stdClass(), 'stdClass'],
+            [new \Exception(), \Exception::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider_dump
+     */
+    public function test_dump($input, $expectedOutput): void
+    {
+        $this->assertSame(
+            $expectedOutput,
+            VariableDumper::dump($input)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an `ensureValid` method allowing the caller to ensure that a specific (user-provided?) value fits an enum's values:

```php
public function setLang(string $lang): self
{
    Lang::ensureValid($lang, __METHOD__);
    $this->lang = $lang;
    return $this;
}
```

When an invalid lang is passed, an `InvalidArgumentException` will be thrown with the following message:

```
Invalid argument provided to MyApp\Entity\User::setLang - expected one of "fr, en, es", got "de"
```

The `VariableDumper` is used to generate the exception message.