### PR TITLE
NamedEnum::values() souldn't require all values to have a name to work properly

### DIFF
--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -45,7 +45,7 @@ abstract class NamedEnum
      */
     public static function values(): array
     {
-        return array_keys(static::$VALUE_NAMES);
+        return array_values(static::constants());
     }
 
     /**

--- a/tests/Enum/NamedEnumTest.php
+++ b/tests/Enum/NamedEnumTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Mesavolt\Tests\Enum;
 
 
+use Mesavolt\Tests\Fixture\IncompleteNamedEnum;
 use PHPUnit\Framework\TestCase;
 use Mesavolt\Tests\Fixture\TestEnum;
 
@@ -146,5 +147,11 @@ final class NamedEnumTest extends TestCase
     {
         TestEnum::ensureValid('1', false, false);
         $this->assertTrue(true);
+    }
+
+    public function testGettingValuesDoesntRequireName()
+    {
+        $values = IncompleteNamedEnum::values();
+        $this->assertCount(3, $values);
     }
 }

--- a/tests/Fixture/IncompleteNamedEnum.php
+++ b/tests/Fixture/IncompleteNamedEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mesavolt\Tests\Fixture;
+
+
+use Mesavolt\Enum\NamedEnum;
+
+abstract class IncompleteNamedEnum extends NamedEnum
+{
+    public const VALUE_1 = 1;
+    public const VALUE_2 = 2;
+    public const VALUE_3 = 3;
+
+    protected static $VALUE_NAMES = [
+        self::VALUE_1 => 'This is 1',
+    ];
+}


### PR DESCRIPTION
Using `array_keys(static::$VALUE_NAMES)` to get all values requires that all values have a name. This shouldn't be the case, even an "incomplete" enum class (i.e. a class without a name for each single value) should be able to give you all its **values**.