### PR TITLE
expose more methods as Twig filters and functions

### DIFF
--- a/src/Enum/NamedEnum.php
+++ b/src/Enum/NamedEnum.php
@@ -58,7 +58,7 @@ abstract class NamedEnum
 
     /**
      * Get an array of all the values indexed by name
-     * (especially useful tu use in a ChoiceType field in a Symfony Form).
+     * (especially useful to use in a ChoiceType field in a Symfony Form).
      */
     public static function choices(): array
     {

--- a/src/Twig/NamedEnumExtension.php
+++ b/src/Twig/NamedEnumExtension.php
@@ -12,14 +12,24 @@ class NamedEnumExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('enum_name', [$this, 'enumName'])
+            new TwigFilter('enum_arrays', [$this, 'enumArrays']),
+            new TwigFilter('enum_choices', [$this, 'enumChoices']),
+            new TwigFilter('enum_constants', [$this, 'enumConstants']),
+            new TwigFilter('enum_name', [$this, 'enumName']),
+            new TwigFilter('enum_names', [$this, 'enumNames']),
+            new TwigFilter('enum_values', [$this, 'enumValues']),
         ];
     }
 
     public function getFunctions()
     {
         return [
-            new TwigFunction('enum_name', [$this, 'enumName'])
+            new TwigFunction('enum_arrays', [$this, 'enumArrays']),
+            new TwigFunction('enum_choices', [$this, 'enumChoices']),
+            new TwigFunction('enum_constants', [$this, 'enumConstants']),
+            new TwigFunction('enum_name', [$this, 'enumName']),
+            new TwigFunction('enum_names', [$this, 'enumNames']),
+            new TwigFunction('enum_values', [$this, 'enumValues']),
         ];
     }
 
@@ -28,4 +38,28 @@ class NamedEnumExtension extends AbstractExtension
         return $class::getName($value);
     }
 
+    public function enumValues($class)
+    {
+        return $class::values();
+    }
+
+    public function enumNames($class)
+    {
+        return $class::names();
+    }
+
+    public function enumConstants($class)
+    {
+        return $class::constants();
+    }
+
+    public function enumArrays($class)
+    {
+        return $class::arrays();
+    }
+
+    public function enumChoices($class)
+    {
+        return $class::choices();
+    }
 }

--- a/tests/Twig/NamedEnumExtensionTest.php
+++ b/tests/Twig/NamedEnumExtensionTest.php
@@ -33,30 +33,68 @@ class NamedEnumExtensionTest extends TestCase
         $extension = $this->twig->getExtension(NamedEnumExtension::class);
         $filters = $extension->getFilters();
 
-        $this->assertCount(1, $filters);
-        $this->assertEquals('enum_name', $filters[0]->getName());
+        $this->assertCount(6, $filters);
+        $this->assertEquals('enum_arrays', $filters[0]->getName());
+        $this->assertEquals('enum_choices', $filters[1]->getName());
+        $this->assertEquals('enum_constants', $filters[2]->getName());
+        $this->assertEquals('enum_name', $filters[3]->getName());
+        $this->assertEquals('enum_names', $filters[4]->getName());
+        $this->assertEquals('enum_values', $filters[5]->getName());
     }
 
     public function testFunctions()
     {
         $functions = $this->extension->getFunctions();
 
-        $this->assertCount(1, $functions);
-        $this->assertEquals('enum_name', $functions[0]->getName());
+        $this->assertCount(6, $functions);
+        $this->assertEquals('enum_arrays', $functions[0]->getName());
+        $this->assertEquals('enum_choices', $functions[1]->getName());
+        $this->assertEquals('enum_constants', $functions[2]->getName());
+        $this->assertEquals('enum_name', $functions[3]->getName());
+        $this->assertEquals('enum_names', $functions[4]->getName());
+        $this->assertEquals('enum_values', $functions[5]->getName());
     }
 
-    public function testCanUseFilter()
+    public function testCanUseFilters()
     {
-        $result = $this->twig->render('test_filter.html.twig', ['enum' => TestEnum::VALUE_1]);
+        $result = $this->twig->render('filters/test_arrays.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('[NAME 1 => 1][NAME 2 => 2][NAME STRING => string]', $result);
 
-        $this->assertEquals('NAME 1', trim($result));
+        $result = $this->twig->render('filters/test_choices.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('NAME 1:1|NAME 2:2|NAME STRING:string|', $result);
+
+        $result = $this->twig->render('filters/test_constants.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('VALUE_1:1|VALUE_2:2|VALUE_STRING:string|', $result);
+
+        $result = $this->twig->render('filters/test_name.html.twig', ['enum' => TestEnum::VALUE_1]);
+        $this->assertEquals('NAME 1', $result);
+
+        $result = $this->twig->render('filters/test_names.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('NAME 1|NAME 2|NAME STRING|', $result);
+
+        $result = $this->twig->render('filters/test_values.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('1|2|string|', $result);
     }
 
-    public function testCanUseFunction()
+    public function testCanUseFunctions()
     {
-        $result = $this->twig->render('test_filter.html.twig', ['enum' => TestEnum::VALUE_2]);
+        $result = $this->twig->render('functions/test_arrays.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('[NAME 1 => 1][NAME 2 => 2][NAME STRING => string]', $result);
 
-        $this->assertEquals('NAME 2', trim($result));
+        $result = $this->twig->render('functions/test_choices.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('NAME 1:1|NAME 2:2|NAME STRING:string|', $result);
+
+        $result = $this->twig->render('functions/test_constants.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('VALUE_1:1|VALUE_2:2|VALUE_STRING:string|', $result);
+
+        $result = $this->twig->render('functions/test_name.html.twig', ['enum' => TestEnum::VALUE_1]);
+        $this->assertEquals('NAME 1', $result);
+
+        $result = $this->twig->render('functions/test_names.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('NAME 1|NAME 2|NAME STRING|', $result);
+
+        $result = $this->twig->render('functions/test_values.html.twig', ['class' => TestEnum::class]);
+        $this->assertEquals('1|2|string|', $result);
     }
 
 }

--- a/tests/Twig/filters/test_arrays.html.twig
+++ b/tests/Twig/filters/test_arrays.html.twig
@@ -1,0 +1,3 @@
+{%- for array in class|enum_arrays -%}
+    [{{- array.name }} => {{ array.value -}}]
+{%- endfor -%}

--- a/tests/Twig/filters/test_choices.html.twig
+++ b/tests/Twig/filters/test_choices.html.twig
@@ -1,0 +1,3 @@
+{%- for label, value in class|enum_choices -%}
+    {{- label }}:{{ value -}}|
+{%- endfor -%}

--- a/tests/Twig/filters/test_constants.html.twig
+++ b/tests/Twig/filters/test_constants.html.twig
@@ -1,0 +1,3 @@
+{%- for name, value in class|enum_constants -%}
+    {{- name }}:{{ value -}}|
+{%- endfor -%}

--- a/tests/Twig/filters/test_name.html.twig
+++ b/tests/Twig/filters/test_name.html.twig
@@ -1,0 +1,1 @@
+{{- enum|enum_name('\\Mesavolt\\Tests\\Fixture\\TestEnum') -}}

--- a/tests/Twig/filters/test_names.html.twig
+++ b/tests/Twig/filters/test_names.html.twig
@@ -1,0 +1,3 @@
+{%- for name in class|enum_names -%}
+    {{- name -}}|
+{%- endfor -%}

--- a/tests/Twig/filters/test_values.html.twig
+++ b/tests/Twig/filters/test_values.html.twig
@@ -1,0 +1,3 @@
+{%- for value in class|enum_values -%}
+    {{- value -}}|
+{%- endfor -%}

--- a/tests/Twig/functions/test_arrays.html.twig
+++ b/tests/Twig/functions/test_arrays.html.twig
@@ -1,0 +1,3 @@
+{%- for array in enum_arrays(class) -%}
+    [{{- array.name }} => {{ array.value -}}]
+{%- endfor -%}

--- a/tests/Twig/functions/test_choices.html.twig
+++ b/tests/Twig/functions/test_choices.html.twig
@@ -1,0 +1,3 @@
+{%- for label, value in enum_choices(class) -%}
+    {{- label }}:{{ value -}}|
+{%- endfor -%}

--- a/tests/Twig/functions/test_constants.html.twig
+++ b/tests/Twig/functions/test_constants.html.twig
@@ -1,0 +1,3 @@
+{%- for name, value in enum_constants(class) -%}
+    {{- name }}:{{ value -}}|
+{%- endfor -%}

--- a/tests/Twig/functions/test_name.html.twig
+++ b/tests/Twig/functions/test_name.html.twig
@@ -1,0 +1,1 @@
+{{- enum_name(enum, '\\Mesavolt\\Tests\\Fixture\\TestEnum') -}}

--- a/tests/Twig/functions/test_names.html.twig
+++ b/tests/Twig/functions/test_names.html.twig
@@ -1,0 +1,3 @@
+{%- for name in enum_names(class) -%}
+    {{- name -}}|
+{%- endfor -%}

--- a/tests/Twig/functions/test_values.html.twig
+++ b/tests/Twig/functions/test_values.html.twig
@@ -1,0 +1,3 @@
+{%- for value in enum_values(class) -%}
+    {{- value -}}|
+{%- endfor -%}

--- a/tests/Twig/test_filter.html.twig
+++ b/tests/Twig/test_filter.html.twig
@@ -1,1 +1,0 @@
-{{ enum|enum_name('\\Mesavolt\\Tests\\Fixture\\TestEnum') }}

--- a/tests/Twig/test_function.html.twig
+++ b/tests/Twig/test_function.html.twig
@@ -1,1 +1,0 @@
-{{ enum_name(enum, '\\Mesavolt\\Tests\\Fixture\\TestEnum') }}


### PR DESCRIPTION
Add filters and functions to expose the following methods: 
- `enum_arrays` : `NamedEnum::arrays()`
- `enum_choices` : `NamedEnum::choices()`
- `enum_constants` : `NamedEnum::constants()`
- `enum_names` : `NamedEnum::names()`
- `enum_values` : `NamedEnum::values()`

Bonus : fix smol typo in `NamedEnum::choices()` doc.